### PR TITLE
#166258838 add an in-app browser screen to show the GitHub profile

### DIFF
--- a/Navigation/NavigationComponent.js
+++ b/Navigation/NavigationComponent.js
@@ -2,6 +2,7 @@ import { createAppContainer, createStackNavigator } from "react-navigation";
 import LoginScreen from "../src/screens/Login/LoginScreen";
 import UsersListScreen from "../src/screens/UsersList/UsersListScreen";
 import DetailsScreen from "../src/screens/DetailsScreen/DetailsScreen";
+import WebViewScreen from "../src/screens/WebViewScreen/WebViewScreen";
 
 const Navigator = createStackNavigator(
   {
@@ -15,7 +16,11 @@ const Navigator = createStackNavigator(
     },
     DetailsScreen: {
       screen: DetailsScreen,
-      navigationOptions: () => ({ title: "Details" })
+      navigationOptions: () => ({ title: "Profile" })
+    },
+    WebViewScreen: {
+      screen: WebViewScreen,
+      navigationOptions: () => ({ title: "Github Profile" })
     },
     Preview: {
       screen: DetailsScreen,

--- a/src/screens/DetailsScreen/DetailsScreen.js
+++ b/src/screens/DetailsScreen/DetailsScreen.js
@@ -9,11 +9,15 @@ const DetailsScreen = props => {
     url,
     username
   } = props.navigation.state.params;
+  const { navigate } = props.navigation;
   return (
     <View style={styles.viewContainer}>
       <Image style={styles.avatar} source={{ uri: avatarUrl }} />
       <Text style={styles.usernameText}>{username}</Text>
-      <TouchableOpacity style={styles.githubUrlLink} onPress={this.openBrowser}>
+      <TouchableOpacity
+        style={styles.githubUrlLink}
+        onPress={() => navigate("WebViewScreen", url)}
+      >
         <Text style={styles.urlText}>{url}</Text>
       </TouchableOpacity>
       <View style={styles.countersContainer}>

--- a/src/screens/WebViewScreen/WebViewScreen.js
+++ b/src/screens/WebViewScreen/WebViewScreen.js
@@ -1,0 +1,9 @@
+import React from "react";
+import { WebView } from "react-native";
+
+const WebViewScreen = props => {
+  const url = props.navigation.state.params;
+  return <WebView source={{ uri: url }} startInLoadingState />;
+};
+
+export default WebViewScreen;


### PR DESCRIPTION
#### What does this PR do?
adds a webview to enable users to open the developer's GitHub profile URL

#### Description of tasks to be done?
- add apollo client implementation
- create and design list item
- add `react-native-dotenv` to manage environment variables
- populate list with data from api
- add navigation from list to a mock details screen
- write tests for the implemented functionality

#### How can this be manually tested?
- clone the repo and check out the branch
- run the application with `npm start`
- send the application to an emulator by typing `a`(android) or `i`(iOS)
- the application should open up on a login screen 
- entering good credentials will take you to a single screen a `loading...` text
- after a few seconds, a list of developers should show up
- clicking on any developer should take you to a details screen
- the details screen has a GitHub link and clicking it opens the in-app browser

#### Screenshots
![demo gif](http://g.recordit.co/AW0J6D8c4z.gif)

#### What are the relevant pivotal tracker stories?
[#166258838](https://www.pivotaltracker.com/story/show/166258838)